### PR TITLE
Fix minimizing apps that should not be minimized

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ Hooks.on("ready", function () {
       // Case 2 - minimize open UI windows
       else if (Object.values(ui.windows).some(w => !w._minimized)) {
          Object.values(ui.windows).forEach(app => {
-            app.minimize();
+            if (app.options.minimizable)
+               app.minimize();
          });
       }
 


### PR DESCRIPTION
There are some applications that may be open that cannot be minimized. For example the Small Time module displays a small Day Cycle window in the bottom left corner. This module is erroneously minimizing that window which has no way to be restored and becomes effectively broken.